### PR TITLE
Get permissions strings from comm-central, not mozilla-central

### DIFF
--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -86,7 +86,7 @@ def update_webext_descriptions(url, locale='en-US', create=True, **kw):
             match = re.match(WEBEXTPERMS_DESCRIPTION_REGEX, line)
             if match:
                 (perm, description) = match.groups()
-                description = description.replace('%S', u'Firefox')
+                description = description.replace('%S', u'Thunderbird')
                 if create:
                     log.info(u'Adding permission "%s" = "%s"' %
                              (perm, description))

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1876,11 +1876,11 @@ DEFAULT_FXA_CONFIG_NAME = 'default'
 ALLOWED_FXA_CONFIGS = ['default']
 
 WEBEXT_PERM_DESCRIPTIONS_URL = (
-    'https://hg.mozilla.org/mozilla-central/raw-file/tip/'
-    'browser/locales/en-US/chrome/browser/browser.properties')
+    'https://hg.mozilla.org/comm-central/raw-file/tip/'
+    'mail/locales/en-US/chrome/messenger/addons.properties')
 WEBEXT_PERM_DESCRIPTIONS_LOCALISED_URL = (
     'https://hg.mozilla.org/l10n-central/{locale}/raw-file/tip/'
-    'browser/chrome/browser/browser.properties')
+    'mail/chrome/messenger/addons.properties')
 
 # List all jobs that should be callable with cron here.
 # syntax is: job_and_method_name: full.package.path


### PR DESCRIPTION
This *doesn't* fix #73, but it does give the front end the right strings to use.