### PR TITLE
Command to remove firefox and android addons

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -7,7 +7,7 @@ from olympia import amo
 from olympia.addons.models import Addon
 from olympia.addons.tasks import (
     add_dynamic_theme_tag, add_firefox57_tag, bump_appver_for_legacy_addons,
-    delete_addon_not_compatible_with_firefoxes,
+    delete_addon_not_compatible_with_thunderbird,
     delete_obsolete_applicationsversions,
     find_inconsistencies_between_es_and_db,
     migrate_legacy_dictionaries_to_webextension,
@@ -66,14 +66,6 @@ tasks = {
             ~Q(type=amo.ADDON_PERSONA)
         ]
     },
-    # Run this once we've disallowed new submissions not targeting Firefox and
-    # addons.thunderbird.net is live.
-    'delete_addons_not_compatible_with_firefoxes': {
-        'method': delete_addon_not_compatible_with_firefoxes,
-        'qs': [Q(status=amo.STATUS_PUBLIC),
-               ~Q(appsupport__app__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id))],
-        'post': delete_obsolete_applicationsversions,
-    },
     'add_dynamic_theme_tag_for_theme_api': {
         'method': add_dynamic_theme_tag,
         'qs': [
@@ -97,6 +89,13 @@ tasks = {
               appsupport__app__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id),
               _current_version__files__is_webextension=True),
         ],
+    },
+    # Copy of the TB clean up, but for Firefox addons
+    'delete_addons_not_compatible_with_thunderbird': {
+        'method': delete_addon_not_compatible_with_thunderbird,
+        'qs': [Q(status=amo.STATUS_PUBLIC),
+               ~Q(appsupport__app__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id))],
+        'post': delete_obsolete_applicationsversions,
     },
 }
 

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -90,7 +90,6 @@ tasks = {
               _current_version__files__is_webextension=True),
         ],
     },
-    # Copy of the TB clean up, but for Firefox addons
     'delete_addons_not_compatible_with_thunderbird': {
         'method': delete_addon_not_compatible_with_thunderbird,
         'qs': [Q(status=amo.STATUS_PUBLIC),

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -675,9 +675,9 @@ def delete_addon_not_compatible_with_thunderbird(ids, **kw):
     qs = Addon.objects.filter(id__in=ids)
     for addon in qs:
         with transaction.atomic():
-            # Only remove the old android appsupport, unsure if removing amo.FIREFOX.id appsupport might break something...
+            # Remove addon appsupport versions for android and firefox
             addon.appsupport_set.filter(
-                app__in=(amo.ANDROID.id,)).delete()
+                app__in=(amo.ANDROID.id, amo.FIREFOX.id)).delete()
             addon.delete()
 
 

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -664,28 +664,29 @@ def migrate_lwts_to_static_themes(ids, **kw):
 
 @task
 @use_primary_db
-def delete_addon_not_compatible_with_firefoxes(ids, **kw):
+def delete_addon_not_compatible_with_thunderbird(ids, **kw):
     """
     Delete the specified add-ons.
-    Used by process_addons --task=delete_addons_not_compatible_with_firefoxes
+    Used by process_addons --task=delete_addons_not_compatible_with_thunderbird
     """
     log.info(
-        'Deleting addons not compatible with firefoxes %d-%d [%d].',
+        'Deleting addons not compatible with thunderbird %d-%d [%d].',
         ids[0], ids[-1], len(ids))
     qs = Addon.objects.filter(id__in=ids)
     for addon in qs:
         with transaction.atomic():
+            # Only remove the old android appsupport, unsure if removing amo.FIREFOX.id appsupport might break something...
             addon.appsupport_set.filter(
-                app__in=(amo.FIREFOX.id, amo.ANDROID.id)).delete()
+                app__in=(amo.ANDROID.id,)).delete()
             addon.delete()
 
 
 @task
 @use_primary_db
 def delete_obsolete_applicationsversions(**kw):
-    """Delete ApplicationsVersions objects not relevant for Firefoxes."""
+    """Delete ApplicationsVersions objects not relevant for Thunderbird/Seamonkey."""
     qs = ApplicationsVersions.objects.exclude(
-        application__in=(amo.FIREFOX.id, amo.ANDROID.id))
+        application__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id))
     for av in qs.iterator():
         av.delete()
 

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -524,10 +524,10 @@ class BumpAppVerForLegacyAddonsTestCase(AMOPaths, TestCase):
         assert apv.max != self.firefox_56_star
 
 
-class TestDeleteAddonsNotCompatibleWithFirefoxes(TestCase):
+class TestDeleteAddonsNotCompatibleWithThunderbird(TestCase):
     def make_the_call(self):
         call_command('process_addons',
-                     task='delete_addons_not_compatible_with_firefoxes')
+                     task='delete_addons_not_compatible_with_thunderbird')
 
     def test_basic(self):
         av_min, _ = AppVersion.objects.get_or_create(
@@ -538,42 +538,42 @@ class TestDeleteAddonsNotCompatibleWithFirefoxes(TestCase):
             application=amo.SEAMONKEY.id, version='2.49.3')
         av_seamonkey_max, _ = AppVersion.objects.get_or_create(
             application=amo.SEAMONKEY.id, version='2.49.*')
-        # Those add-ons should not be deleted, because they are compatible with
-        # at least Firefox or Firefox for Android.
-        addon_factory()  # A pure Firefox add-on
-        addon_factory(version_kw={'application': amo.ANDROID.id})
-        addon_with_both_firefoxes = addon_factory()
-        ApplicationsVersions.objects.get_or_create(
-            application=amo.ANDROID.id,
-            version=addon_with_both_firefoxes.current_version,
-            min=av_min, max=av_max)
-        addon_with_thunderbird_and_android = addon_factory(
-            version_kw={'application': amo.THUNDERBIRD.id})
-        ApplicationsVersions.objects.get_or_create(
-            application=amo.ANDROID.id,
-            version=addon_with_thunderbird_and_android.current_version,
-            min=av_min, max=av_max)
-        addon_with_firefox_and_seamonkey = addon_factory(
-            version_kw={'application': amo.FIREFOX.id})
-        ApplicationsVersions.objects.get_or_create(
-            application=amo.SEAMONKEY.id,
-            version=addon_with_firefox_and_seamonkey.current_version,
-            min=av_seamonkey_min, max=av_seamonkey_max)
-        addon_factory(
-            status=amo.STATUS_NULL,  # Non-public, will cause it to be ignored.
-            version_kw={'application': amo.THUNDERBIRD.id})
+        av_tb_min, _ = AppVersion.objects.get_or_create(
+            application=amo.THUNDERBIRD.id, version='115.1')
+        av_tb_max, _ = AppVersion.objects.get_or_create(
+            application=amo.THUNDERBIRD.id, version='115.*')
 
-        # Those add-ons should be deleted as they are only compatible with
-        # Thunderbird or Seamonkey, or both.
-        addon = addon_factory(version_kw={'application': amo.THUNDERBIRD.id})
-        addon2 = addon_factory(version_kw={'application': amo.SEAMONKEY.id,
-                                           'min_app_version': '2.49.3',
-                                           'max_app_version': '2.49.*'})
-        addon3 = addon_factory(version_kw={'application': amo.THUNDERBIRD.id})
-        ApplicationsVersions.objects.get_or_create(
-            application=amo.SEAMONKEY.id,
-            version=addon3.current_version,
-            min=av_seamonkey_min, max=av_seamonkey_max)
+        def create_addon(version, alt_version = None, min = None, max = None):
+            addon = addon_factory(version_kw={'application': version})
+            # Create a new version, if alt_version is provided it's essentially a release for that platform
+            if alt_version:
+                ApplicationsVersions.objects.get_or_create(
+                    application=alt_version,
+                    version=addon.current_version,
+                    min=min, max=max)
+            return addon
+
+        # These addons should stay
+        good_addons = [
+            # Thunderbird
+            create_addon(amo.THUNDERBIRD.id),
+            # Seamonkey
+            create_addon(amo.SEAMONKEY.id),
+            # Thunderbird and Seamonkey
+            create_addon(amo.THUNDERBIRD.id, amo.SEAMONKEY.id, av_seamonkey_min, av_seamonkey_max),
+            # Firefox and Thunderbird
+            create_addon(amo.FIREFOX.id, amo.THUNDERBIRD.id, av_tb_min, av_tb_max)
+        ]
+
+        # These addons should go
+        bad_addons = [
+            # Firefox
+            create_addon(amo.FIREFOX.id),
+            # Android
+            create_addon(amo.ANDROID.id),
+            # Firefox and Android
+            create_addon(amo.FIREFOX.id, amo.ANDROID.id, min=av_min, max=av_max)
+        ]
 
         # We've manually changed the ApplicationVersions, so let's run
         # update_appsupport() on all public add-ons. In the real world that is
@@ -582,33 +582,38 @@ class TestDeleteAddonsNotCompatibleWithFirefoxes(TestCase):
         # somehow fell through the cracks once a day.
         update_appsupport(Addon.objects.public().values_list('pk', flat=True))
 
-        assert Addon.objects.count() == 9
+        assert Addon.objects.count() == 7
 
         with count_subtask_calls(
-                pa.delete_addon_not_compatible_with_firefoxes) as calls:
+                pa.delete_addon_not_compatible_with_thunderbird) as calls:
             self.make_the_call()
 
+        bad_addons_pk = map(lambda a: a.pk, bad_addons)
+
         assert len(calls) == 1
-        assert calls[0]['kwargs']['args'] == [[addon.pk, addon2.pk, addon3.pk]]
-        assert not Addon.objects.filter(pk=addon.pk).exists()
-        assert not Addon.objects.filter(pk=addon2.pk).exists()
-        assert not Addon.objects.filter(pk=addon3.pk).exists()
+        assert calls[0]['kwargs']['args'] == [bad_addons_pk]
 
-        assert Addon.objects.count() == 6
+        for addon in good_addons:
+            assert Addon.objects.filter(pk=addon.pk).exists()
 
-        # Make sure ApplicationsVersions targeting Thunderbird or Seamonkey are
+        for addon in bad_addons:
+            assert not Addon.objects.filter(pk=addon.pk).exists()
+
+        assert Addon.objects.count() == 4
+
+        # Make sure ApplicationsVersions targeting Android or Firefox are
         # gone.
         assert not ApplicationsVersions.objects.filter(
-            application=amo.SEAMONKEY.id).exists()
+            application=amo.ANDROID.id).exists()
         assert not ApplicationsVersions.objects.filter(
-            application=amo.THUNDERBIRD.id).exists()
+            application=amo.FIREFOX.id).exists()
 
-        # Make sure AppSupport targeting Thunderbird or Seamonkey are gone for
+        # Make sure AppSupport targeting Android or Firefox are gone for
         # add-ons we touched.
         assert not AppSupport.objects.filter(
-            addon__in=(addon, addon2, addon3), app=amo.SEAMONKEY.id).exists()
+            addon__in=bad_addons, app=amo.FIREFOX.id).exists()
         assert not AppSupport.objects.filter(
-            addon__in=(addon, addon2, addon3), app=amo.THUNDERBIRD.id).exists()
+            addon__in=bad_addons, app=amo.ANDROID.id).exists()
 
 
 class TestMigrateLegacyDictionariesToWebextension(TestCase):


### PR DESCRIPTION
Fixes #264 

I've re-worked the original "Nuke TB/Seakmonkey from AMO" command to "Nuke Firefox/Android from ATN". I've adjusted and simplified the test so it's easier to read. The tests pass locally, but feel free to try and run it with `docker-compose exec web pytest ./src/olympia/addons/tests/test_commands.py -k "TestDeleteAddonsNotCompatibleWithThunderbird"`. 😄 

```
collected 31 items / 30 deselected                                                                                                                                                                                   

src/olympia/addons/tests/test_commands.py::TestDeleteAddonsNotCompatibleWithThunderbird::test_basic Using existing test database for alias 'default'...
PASSED
```

Let me know if there's any other factors that we need to consider here.