### PR TITLE
Add web extension permission description to the permissions tab.

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8364,3 +8364,6 @@ msgstr "Binär"
 
 msgid "Non-binary"
 msgstr "Nicht-binär"
+
+msgid "Have full, unrestricted access to Thunderbird, and your computer"
+msgstr "Vollständiger Zugriff auf Thunderbird und Ihren Computer"

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -8865,3 +8865,6 @@ msgstr "Binary"
 
 msgid "Non-binary"
 msgstr "Non-binary"
+
+msgid "Have full, unrestricted access to Thunderbird, and your computer"
+msgstr "Have full, unrestricted access to Thunderbird, and your computer"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -8391,3 +8391,6 @@ msgstr "Binaire"
 
 msgid "Non-binary"
 msgstr "Non binaire"
+
+msgid "Have full, unrestricted access to Thunderbird, and your computer"
+msgstr "Avoir un accès complet et illimité à Thunderbird et à votre ordinateur"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -8419,3 +8419,6 @@ msgstr "Compilato"
 
 msgid "Non-binary"
 msgstr "Non compilato"
+
+msgid "Have full, unrestricted access to Thunderbird, and your computer"
+msgstr "Avere accesso completo e senza restrizioni a Thunderbird e al computer"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -8400,3 +8400,6 @@ msgstr "Binarny"
 
 msgid "Non-binary"
 msgstr "Niebinarny"
+
+msgid "Have full, unrestricted access to Thunderbird, and your computer"
+msgstr "Pełny, nieograniczony dostęp do programu Thunderbird i komputera"

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1477,7 +1477,8 @@ class Addon(OnChangeMixin, ModelBase):
         return (self.type == amo.ADDON_EXTENSION and
                 version and version.all_files[0] and
                 (not version.all_files[0].is_webextension or
-                 version.all_files[0].webext_permissions))
+                 version.all_files[0].webext_permissions or
+                 version.all_files[0].is_experiment))
 
     @property
     def needs_admin_code_review(self):

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -290,17 +290,21 @@
           <p>
           {{ _('Some add-ons ask for permission to perform certain functions (example: a tab management add-on will ask permission to access your browser’s tab system).') }}
           </p>
+          <p>
+          {{ _('Since you’re in control of your Thunderbird, the choice to grant or deny these requests is yours. Accepting permissions does not inherently compromise your browser’s performance or security, but in some rare cases risk may be involved.') }}
+          </p>
         </div>
         <div>
           <p>
             {# l10n: This is a header of a list of things the add-on can do. #}
             <h3>{{ _('This add-on can:') }}</h3>
             <ul class="webext-permissions-list">
-              {% for perm in permissions %}
-                <li class="webext-permissions-list">{{ perm.description|e }}</li>
-              {% endfor %}
               {% if addon.current_version.all_files[0].is_experiment %}
                 <li class="webext-permissions-list"><b>{{ _('Have full, unrestricted access to Thunderbird, and your computer') }}</b></li>
+              {% else %}
+                {% for perm in permissions %}
+                  <li class="webext-permissions-list">{{ perm.description|e }}</li>
+                {% endfor %}
               {% endif %}
             </ul>
           </p>

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -289,8 +289,6 @@
         <div class="prose">
           <p>
           {{ _('Some add-ons ask for permission to perform certain functions (example: a tab management add-on will ask permission to access your browser’s tab system).') }}
-          </p><p>
-          {{ _('Since you’re in control of your Thunderbird, the choice to grant or deny these requests is yours. Accepting permissions does not inherently compromise your browser’s performance or security, but in some rare cases risk may be involved.') }}
           </p>
         </div>
         <div>
@@ -301,6 +299,9 @@
               {% for perm in permissions %}
                 <li class="webext-permissions-list">{{ perm.description|e }}</li>
               {% endfor %}
+              {% if addon.current_version.all_files[0].is_experiment %}
+                <li class="webext-permissions-list"><b>{{ _('Have full, unrestricted access to Thunderbird, and your computer') }}</b></li>
+              {% endif %}
             </ul>
           </p>
         </div>


### PR DESCRIPTION
I still need to test this, but the intention is to display the normal web experiment permission description on ATN. 

Based on tb.net country rankings I've grabbed some potentially popular localizations off of Pontoon. ATN used to import the actual descriptions, but that hasn't been updated since Thunderbird migrated to fluent strings. So had to do some manual work.

I also removed the second sentence since it was technically untrue, as we don't have modular permission granting. (Correct me if I'm wrong there.) Due to the fact this project isn't actively localized I can't really just edit the sentence to only say "Hey it can be dangerous!"

 