### PR TITLE
Image Restrictions

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1540,7 +1540,7 @@ class Addon(OnChangeMixin, ModelBase):
 
         version = self.versions.latest()
 
-        if not version or not version.all_files[0]:
+        if not version or len(version.all_files) == 0:
             return False
 
         permissions = version.all_files[0].webext_permissions_list

--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -21,6 +21,7 @@ from django.utils.translation import activate, ugettext_lazy as _
 
 import MySQLdb as mysql
 from corsheaders.middleware import CorsMiddleware as _CorsMiddleware
+from PIL import Image
 
 from olympia import amo
 from olympia.amo.utils import render
@@ -352,3 +353,18 @@ class CorsMiddleware(_CorsMiddleware, MiddlewareMixin):
     https://github.com/mstriemer/django-cors-headers/pull/3 is merged and a
     new release of django-cors-headers-multi is available."""
     pass
+
+
+class ImageUploadRestrictionMiddleware(object):
+    """Restricts Pillow to only allow processing of PNG, JPEG, and GIF images."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        Image.init()
+        Image.ID = ['PNG', 'JPEG', 'GIF']
+
+        response = self.get_response(request)
+
+        return response

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -462,6 +462,8 @@ SECURE_HSTS_SECONDS = 31536000
 USE_X_FORWARDED_PORT = True
 
 MIDDLEWARE = (
+    # We want this to boot first to restrict Pillow image types
+    'olympia.amo.middleware.ImageUploadRestrictionMiddleware',
     # Our middleware to make safe requests non-atomic needs to be at the top.
     'olympia.amo.middleware.NonAtomicRequestsForSafeHttpMethodsMiddleware',
     # Test if it's an API request first so later middlewares don't need to.


### PR DESCRIPTION
Django's ImageField seems to add its own error if Pillow cannot parse an image. I spent a little longer than I'd like looking for a way to turn "Image not supported" into "Png or jpeg only pls". 🤷 

