### PR TITLE
Remove Personas

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -8,6 +8,8 @@ from olympia.addons.models import Addon
 from olympia.addons.tasks import (
     add_dynamic_theme_tag, add_firefox57_tag, bump_appver_for_legacy_addons,
     delete_addon_not_compatible_with_thunderbird,
+    delete_personas,
+    output_personas,
     delete_obsolete_applicationsversions,
     find_inconsistencies_between_es_and_db,
     migrate_legacy_dictionaries_to_webextension,
@@ -95,6 +97,15 @@ tasks = {
         'qs': [Q(status=amo.STATUS_PUBLIC),
                ~Q(appsupport__app__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id))],
         'post': delete_obsolete_applicationsversions,
+    },
+    'delete_personas': {
+        'method': delete_personas,
+        'qs': [Q(type=amo.ADDON_PERSONA)],
+        'post': delete_obsolete_applicationsversions,
+    },
+    'output_personas': {
+        'method': output_personas,
+        'qs': [Q(type=amo.ADDON_PERSONA)],
     },
 }
 

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -101,7 +101,6 @@ tasks = {
     'delete_personas': {
         'method': delete_personas,
         'qs': [Q(type=amo.ADDON_PERSONA)],
-        'post': delete_obsolete_applicationsversions,
     },
     'output_personas': {
         'method': output_personas,

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -455,13 +455,13 @@ class Addon(OnChangeMixin, ModelBase):
         return self.status or Version.unfiltered.filter(addon=self).exists()
 
     @transaction.atomic
-    def delete(self, msg='', reason=''):
+    def delete(self, msg='', reason='', hard=False):
         # To avoid a circular import
         from . import tasks
         from olympia.versions import tasks as version_tasks
         # Check for soft deletion path. Happens only if the addon status isn't
         # 0 (STATUS_INCOMPLETE) with no versions.
-        soft_deletion = self.is_soft_deleteable()
+        soft_deletion = not hard and self.is_soft_deleteable()
         if soft_deletion and self.status == amo.STATUS_DELETED:
             # We're already done.
             return

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import uuid
+import csv
 from datetime import datetime
 
 from django.conf import settings
@@ -680,6 +681,37 @@ def delete_addon_not_compatible_with_thunderbird(ids, **kw):
                 app__in=(amo.ANDROID.id, amo.FIREFOX.id)).delete()
             addon.delete()
 
+
+@task
+@use_primary_db
+def output_personas(ids, **kw):
+    """
+    Output the specified add-ons.
+    Used by process_addons --task=output_personas
+    """
+    log.info(
+        'Outputting personas %d-%d [%d].',
+        ids[0], ids[-1], len(ids))
+    qs = Addon.objects.filter(pk__in=ids)
+    persona_csv = csv.writer(open('personas.csv', 'ab'))
+    for addon in qs:
+        persona_csv.writerow([addon.id, addon.name, addon.get_detail_url()])
+
+@task
+@use_primary_db
+def delete_personas(ids, **kw):
+    """
+    Delete the specified add-ons.
+    Used by process_addons --task=delete_personas
+    """
+    log.info(
+        'Deleting personas %d-%d [%d].',
+        ids[0], ids[-1], len(ids))
+    qs = Addon.objects.filter(pk__in=ids)
+    for addon in qs:
+        with transaction.atomic():
+            addon.persona.delete()
+            addon.delete()
 
 @task
 @use_primary_db

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -711,7 +711,7 @@ def delete_personas(ids, **kw):
     for addon in qs:
         with transaction.atomic():
             addon.persona.delete()
-            addon.delete()
+            addon.delete(hard=True)
 
 @task
 @use_primary_db

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -708,10 +708,12 @@ def delete_personas(ids, **kw):
         'Deleting personas %d-%d [%d].',
         ids[0], ids[-1], len(ids))
     qs = Addon.objects.filter(pk__in=ids)
+    pause_all_tasks()
     for addon in qs:
         with transaction.atomic():
             addon.persona.delete()
             addon.delete(hard=True)
+    resume_all_tasks()
 
 @task
 @use_primary_db

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -683,7 +683,6 @@ class TestDeletePersonas(TestCase):
 
         assert Addon.objects.count() == 9
 
-        print("Deleteing 'em all")
         with count_subtask_calls(pa.delete_personas) as calls:
             self.make_the_call()
 

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -1,5 +1,8 @@
+import csv
+import os
 from contextlib import contextmanager
 
+import six
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -12,7 +15,7 @@ from olympia import amo
 from olympia.activity.models import AddonLog
 from olympia.addons.management.commands import (
     approve_addons, process_addons as pa)
-from olympia.addons.models import Addon, AppSupport
+from olympia.addons.models import Addon, AppSupport, Persona
 from olympia.addons.tasks import update_appsupport
 from olympia.amo.tests import (
     AMOPaths, TestCase, addon_factory, version_factory)
@@ -529,7 +532,6 @@ class TestDeleteAddonsNotCompatibleWithThunderbird(TestCase):
         call_command('process_addons',
                      task='delete_addons_not_compatible_with_thunderbird')
 
-    @pytest.mark.xfail(reason="Test and the associated command are Firefox specific.")
     def test_basic(self):
         av_min, _ = AppVersion.objects.get_or_create(
             application=amo.ANDROID.id, version='48.0')
@@ -615,6 +617,138 @@ class TestDeleteAddonsNotCompatibleWithThunderbird(TestCase):
             addon__in=bad_addons, app=amo.FIREFOX.id).exists()
         assert not AppSupport.objects.filter(
             addon__in=bad_addons, app=amo.ANDROID.id).exists()
+
+
+
+class TestDeletePersonas(TestCase):
+    def make_the_call(self):
+        call_command('process_addons',
+                     task='delete_personas')
+
+    def test_basic(self):
+        av_min, _ = AppVersion.objects.get_or_create(
+            application=amo.ANDROID.id, version='48.0')
+        av_max, _ = AppVersion.objects.get_or_create(
+            application=amo.ANDROID.id, version='48.*')
+        av_seamonkey_min, _ = AppVersion.objects.get_or_create(
+            application=amo.SEAMONKEY.id, version='2.49.3')
+        av_seamonkey_max, _ = AppVersion.objects.get_or_create(
+            application=amo.SEAMONKEY.id, version='2.49.*')
+        av_tb_min, _ = AppVersion.objects.get_or_create(
+            application=amo.THUNDERBIRD.id, version='115.1')
+        av_tb_max, _ = AppVersion.objects.get_or_create(
+            application=amo.THUNDERBIRD.id, version='115.*')
+
+        def create_addon(version, is_persona = True, alt_version = None, min = None, max = None):
+            addon = addon_factory(
+                version_kw={'application': version},
+                type=amo.ADDON_PERSONA if is_persona else amo.ADDON_EXTENSION
+            )
+            # Create a new version, if alt_version is provided it's essentially a release for that platform
+            if alt_version:
+                ApplicationsVersions.objects.get_or_create(
+                    application=alt_version,
+                    version=addon.current_version,
+                    min=min, max=max)
+            return addon
+
+        # These addons should stay
+        extensions = [
+            # Thunderbird
+            create_addon(amo.THUNDERBIRD.id, is_persona=False),
+            # Seamonkey
+            create_addon(amo.SEAMONKEY.id, is_persona=False),
+            # Thunderbird and Seamonkey
+            create_addon(amo.THUNDERBIRD.id, is_persona=False, alt_version=amo.SEAMONKEY.id, min=av_seamonkey_min, max=av_seamonkey_max),
+            # Firefox and Thunderbird
+            create_addon(amo.FIREFOX.id, is_persona=False, alt_version=amo.THUNDERBIRD.id, min=av_tb_min, max=av_tb_max)
+        ]
+
+        # These addons should go
+        personas = [
+            # Firefox, it's the only platform that supports it! (Well not anymore...)
+            create_addon(amo.FIREFOX.id),
+            create_addon(amo.FIREFOX.id),
+            create_addon(amo.FIREFOX.id),
+            create_addon(amo.FIREFOX.id),
+            create_addon(amo.FIREFOX.id),
+        ]
+
+        # We've manually changed the ApplicationVersions, so let's run
+        # update_appsupport() on all public add-ons. In the real world that is
+        # done automatically when uploading a new version, either through the
+        # version_changed signal or via a cron that catches any versions that
+        # somehow fell through the cracks once a day.
+        update_appsupport(Addon.objects.public().values_list('pk', flat=True))
+
+        assert Addon.objects.count() == 9
+
+        print("Deleteing 'em all")
+        with count_subtask_calls(pa.delete_personas) as calls:
+            self.make_the_call()
+
+        personas_pk = map(lambda a: a.pk, personas)
+        personas_object_pk = map(lambda a: a.persona.pk, personas)
+
+        assert len(calls) == 1
+        assert calls[0]['kwargs']['args'] == [personas_pk]
+
+        for addon in extensions:
+            assert Addon.objects.filter(pk=addon.pk).exists()
+
+        for addon in personas:
+            assert not Addon.objects.filter(pk=addon.pk).exists()
+
+        # Make sure the persona data is also deleted
+        for persona_pk in personas_object_pk:
+            assert not Persona.objects.filter(pk=persona_pk).exists()
+
+        assert Addon.objects.count() == 4
+
+@pytest.mark.slow_tests
+class TestOutputPersonas(TestCase):
+    def make_the_call(self):
+        call_command('process_addons',
+                     task='output_personas')
+
+    def test_basic(self):
+        def create_addon(version):
+            addon = addon_factory(
+                version_kw={'application': version},
+                type=amo.ADDON_PERSONA
+            )
+            return addon
+
+        personas = []
+
+        file_name = 'personas.csv'
+
+        # Nuke the file
+        with open(file_name, 'wb') as fh:
+            pass
+
+        # They're batched by 100s so we want to make sure append works
+        for idx in range(0, 101):
+            personas.append(create_addon(amo.FIREFOX.id))
+
+        update_appsupport(Addon.objects.public().values_list('pk', flat=True))
+
+        with count_subtask_calls(pa.output_personas) as calls:
+            self.make_the_call()
+
+        assert len(calls) == 2
+
+        personas_csv = csv.reader(open(file_name, 'rb'))
+        idx = 0
+        for row in personas_csv:
+            persona = personas[idx]
+            assert row[0] == six.text_type(persona.id)
+            assert row[1].decode('utf-8') == six.text_type(persona.name)
+            assert row[2] == persona.get_detail_url()
+            idx += 1
+
+        # Nuke the file
+        os.remove(file_name)
 
 
 class TestMigrateLegacyDictionariesToWebextension(TestCase):

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -22,8 +22,7 @@ from olympia.amo.tests import (
 from olympia.applications.models import AppVersion
 from olympia.files.models import FileValidation, WebextPermission
 from olympia.reviewers.models import AutoApprovalSummary, ReviewerScore
-from olympia.versions.models import ApplicationsVersions
-
+from olympia.versions.models import ApplicationsVersions, Version
 
 # Where to monkeypatch "lib.crypto.tasks.sign_addons" so it's correctly mocked.
 SIGN_ADDONS = 'olympia.addons.management.commands.sign_addons.sign_addons'
@@ -682,6 +681,7 @@ class TestDeletePersonas(TestCase):
         update_appsupport(Addon.objects.public().values_list('pk', flat=True))
 
         assert Addon.objects.count() == 9
+        assert Version.objects.count() == 9
 
         with count_subtask_calls(pa.delete_personas) as calls:
             self.make_the_call()
@@ -702,7 +702,11 @@ class TestDeletePersonas(TestCase):
         for persona_pk in personas_object_pk:
             assert not Persona.objects.filter(pk=persona_pk).exists()
 
-        assert Addon.objects.count() == 4
+        # Ensure Addon and their versions are now down to 4
+        assert Addon.unfiltered.count() == 4
+        assert Version.unfiltered.count() == 4
+        # Personas isn't soft-deletable, so we can just use objects
+        assert Persona.objects.count() == 0
 
 @pytest.mark.slow_tests
 class TestOutputPersonas(TestCase):


### PR DESCRIPTION
Fixes #284 

There's two commands added here: 
* output_personas - Writes the persona id, name, and relative path to a `./personas.csv`. I'm expecting that csv to be around 60-100mb. 😱 
* delete_personas - Deletes persona and addons

I've also added a hard parameter (matching some other delete functions) to hard delete an addon. By default they soft delete (and also that sends an email to the addon owner 😱) which basically sets the status to deleted and removes it from normal object listing. We don't need these anymore, so lets just remove it entirely from the db. 

After I get the csv of personas I'll create a github repo with some markdown lists pointing to AMO. (Might have to the files down by by alphabetical order.)