### PR TITLE
Cache unauthenticated GET/HEAD requests for one hour.

### DIFF
--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -368,3 +368,22 @@ class ImageUploadRestrictionMiddleware(object):
         response = self.get_response(request)
 
         return response
+
+
+class CacheUnauthenticatedViews(object):
+    """Adds cache-control header to the response for unauthenticated GET/HEAD requests"""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        # Only add cache-control if it's a GET/HEAD request, and they're not logged in.
+        if (
+            (request.method == 'GET' or request.method == 'HEAD')
+            and (not request.user or not request.user.is_authenticated)
+        ):
+            response['Cache-Control'] = "max-age={0}".format(60 * 60)  # One hour
+
+        return response

--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -384,6 +384,6 @@ class CacheUnauthenticatedViews(object):
             (request.method == 'GET' or request.method == 'HEAD')
             and (not request.user or not request.user.is_authenticated)
         ):
-            response['Cache-Control'] = "max-age={0}".format(60 * 60)  # One hour
+            response['Cache-Control'] = "max-age={0}".format(settings.CACHE_CONTROL_MAX_AGE)
 
         return response

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1968,3 +1968,5 @@ AKISMET_API_URL = 'https://{api_key}.rest.akismet.com/1.1/{action}'
 AKISMET_API_KEY = env('AKISMET_API_KEY', default=None)
 AKISMET_API_TIMEOUT = 5
 AKISMET_REAL_SUBMIT = False
+
+CACHE_CONTROL_MAX_AGE=60 * 60  # One hour by default

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -517,6 +517,7 @@ MIDDLEWARE = (
 
     'olympia.amo.middleware.ScrubRequestOnException',
     'olympia.amo.middleware.RequestIdMiddleware',
+    'olympia.amo.middleware.CacheUnauthenticatedViews',
 )
 
 # Auth


### PR DESCRIPTION
This will affect all GET/HEAD requests even api calls. I'm not sure if that's something we majorly care about though. 

In private browser on my dev environment, not being logged in I get `cache-control: max-age=3600`, otherwise being logged in I don't get a cache-control header. Let me know if you want an explicit max-age=0 header anywhere.

<img width="674" alt="image" src="https://github.com/thunderbird/addons-server/assets/97147377/fc368ce2-421e-4384-9a42-0490630c91e4">
