### PR TITLE
Remove personas from profile

### DIFF
--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -1,3 +1,4 @@
+{% if persona is not None %}
 {% if size == 'large' %}
   <div class="persona persona-{{ size }}">
     <div class="persona-inner">
@@ -112,4 +113,5 @@
       </div>
     {% endif %}
   </div>
+{% endif %}
 {% endif %}

--- a/src/olympia/addons/templatetags/jinja_helpers.py
+++ b/src/olympia/addons/templatetags/jinja_helpers.py
@@ -236,6 +236,12 @@ def new_context(context, **kw):
 @jinja2.contextfunction
 def persona_preview(context, persona, size='large', linked=True, extra=None,
                     details=False, title=False, caption=False, url=None):
+    # Signal to the html that we don't want to render anything
+    if persona is None:
+        c = dict(context.items())
+        c.update({'persona': None})
+        return context.items()
+
     preview_map = {'large': persona.preview_url,
                    'small': persona.thumb_url}
     addon = persona.addon

--- a/src/olympia/users/templates/users/profile.html
+++ b/src/olympia/users/templates/users/profile.html
@@ -63,19 +63,6 @@
   </div>
 {% endif %}
 
-{% if personas %}
-  <div id="my-themes" class="island c">
-    <a href="{{ profile.get_themes_url_path() }}" class="button view-all">
-      {{ _('View all') }}</a>
-    {% if limited_personas %}
-      <h2>{{ _("My Most Popular Themes") }}</h2>
-    {% else %}
-      <h2>{{ _("Themes I've created") }}</h2>
-    {% endif %}
-    {{ personas|impala_persona_grid(cols=5, pagesize=THEMES_LIMIT) }}
-  </div>
-{% endif %}
-
 {% if own_coll or fav_coll %}
 <aside class="secondary" id="my-collections">
   <div class="island">


### PR DESCRIPTION
Fixes #249 

Seems to be a side-effect of https://github.com/thunderbird/addons-server/issues/284. Some personas still have their addons but not their persona record. I'm not sure why, and it's possible these are the personas that were causing the celery tasks to fail. Follow up ticket: https://github.com/thunderbird/addons-server/issues/295

Tested on stage, and it works. Although there's some small tweaks I could do to make it prettier. (Like not counting personas towards # of themes.)

I also added a check in the persona preview template fragment. 

