### PR TITLE
Use redirect_uri instead of redirect_url

### DIFF
--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -29,9 +29,9 @@ def fxa_login_url(config, state, next_path=None, action=None):
     if next_path and is_safe_url(next_path):
         state += ':' + urlsafe_b64encode(next_path.encode('utf-8')).rstrip('=')
     query = {
-        'client_id': config['client_id'],
-        'redirect_url': config['redirect_url'],
-        'scope': config['scope'],
+        'client_id': config.get('client_id'),
+        'redirect_uri': config.get('redirect_url'),
+        'scope': config.get('scope', 'profile'),
         'state': state,
     }
     if action is not None:


### PR DESCRIPTION
Needs testing on stage, but fxa has some legacy handling for redirect_url (or maybe with just a missing redirect_uri param) that sends the user to ATN or AMO depending on some paths. 

The correct parameter is redirect_uri which works nicely locally. 